### PR TITLE
config/samples: Populate with example data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,6 @@ Dockerfile.cross
 *.swp
 *.swo
 *~
+
+# secrets
 clouds.yaml
-/clouds

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,4 +1,10 @@
 ## Append samples of your project ##
+generatorOptions:
+  disableNameSuffixHash: true
+secretGenerator:
+- name: openstack-clouds
+  files:
+  - clouds.yaml
 resources:
 - openstack_v1alpha1_openstackcloud.yaml
 - openstack_v1alpha1_openstackflavor.yaml

--- a/config/samples/openstack_v1alpha1_openstackcloud.yaml
+++ b/config/samples/openstack_v1alpha1_openstackcloud.yaml
@@ -7,6 +7,11 @@ metadata:
     app.kubernetes.io/part-of: gopherkube
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: gopherkube
-  name: openstackcloud-sample
+  name: osp1
 spec:
-  # TODO(user): Add fields here
+  cloud: cloud # REPLACE with the name of the target cloud in clouds.yaml
+  credentials:
+    source: secret
+    secretRef:
+      name: openstack-clouds
+      key: clouds.yaml

--- a/config/samples/openstack_v1alpha1_openstackflavor.yaml
+++ b/config/samples/openstack_v1alpha1_openstackflavor.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/part-of: gopherkube
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: gopherkube
-  name: openstackflavor-sample
+  name: small
 spec:
-  # TODO(user): Add fields here
+  cloud: osp1
+  id: 889ef5ab-92c2-4701-bf82-8209da1d29f4 # REPLACE with the ID of an existing flavor

--- a/config/samples/openstack_v1alpha1_openstackfloatingip.yaml
+++ b/config/samples/openstack_v1alpha1_openstackfloatingip.yaml
@@ -7,6 +7,8 @@ metadata:
     app.kubernetes.io/part-of: gopherkube
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: gopherkube
-  name: openstackfloatingip-sample
+  name: fip-1
 spec:
-  # TODO(user): Add fields here
+  cloud: osp1
+  description: Provisioned by gopherkube
+  floatingNetwork: external

--- a/config/samples/openstack_v1alpha1_openstackimage.yaml
+++ b/config/samples/openstack_v1alpha1_openstackimage.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/part-of: gopherkube
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: gopherkube
-  name: openstackimage-sample
+  name: ubuntu
 spec:
-  # TODO(user): Add fields here
+  cloud: osp1
+  id: da314c41-19bf-486a-b8da-39ca51fd17de # REPLACE with the ID of an existing image

--- a/config/samples/openstack_v1alpha1_openstacknetwork.yaml
+++ b/config/samples/openstack_v1alpha1_openstacknetwork.yaml
@@ -7,6 +7,22 @@ metadata:
     app.kubernetes.io/part-of: gopherkube
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: gopherkube
-  name: openstacknetwork-sample
+  name: external
 spec:
-  # TODO(user): Add fields here
+  cloud: osp1
+  id: 43613b84-e1fb-44a4-b1ea-c530edc49018 # REPLACE with the ID of the existing external network
+  unmanaged: true
+---
+apiVersion: openstack.gopherkube.dev/v1alpha1
+kind: OpenStackNetwork
+metadata:
+  labels:
+    app.kubernetes.io/name: openstacknetwork
+    app.kubernetes.io/instance: openstacknetwork-sample
+    app.kubernetes.io/part-of: gopherkube
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: gopherkube
+  name: network-1
+spec:
+  cloud: osp1
+  name: my-new-network

--- a/config/samples/openstack_v1alpha1_openstacksecuritygroup.yaml
+++ b/config/samples/openstack_v1alpha1_openstacksecuritygroup.yaml
@@ -7,6 +7,23 @@ metadata:
     app.kubernetes.io/part-of: gopherkube
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: gopherkube
-  name: openstacksecuritygroup-sample
+  name: default
 spec:
-  # TODO(user): Add fields here
+  cloud: osp1
+  id: 01951585-93f7-42c9-9dee-37ce0d476bb2 # REPLACE with the ID of the existing "default" security group
+  unmanaged: true
+---
+apiVersion: openstack.gopherkube.dev/v1alpha1
+kind: OpenStackSecurityGroup
+metadata:
+  labels:
+    app.kubernetes.io/name: openstacksecuritygroup
+    app.kubernetes.io/instance: openstacksecuritygroup-sample
+    app.kubernetes.io/part-of: gopherkube
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: gopherkube
+  name: workstation
+spec:
+  cloud: osp1
+  name: workstation
+  description: 'For remote work'

--- a/config/samples/openstack_v1alpha1_openstacksecuritygrouprule.yaml
+++ b/config/samples/openstack_v1alpha1_openstacksecuritygrouprule.yaml
@@ -7,6 +7,73 @@ metadata:
     app.kubernetes.io/part-of: gopherkube
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: gopherkube
-  name: openstacksecuritygrouprule-sample
+  name: workstation-ssh-ipv4
 spec:
-  # TODO(user): Add fields here
+  cloud: osp1
+  securityGroup: workstation
+  direction: ingress
+  description: ssh
+  portRangeMin: 22
+  portRangeMax: 22
+  protocol: TCP
+  etherType: IPv4
+---
+apiVersion: openstack.gopherkube.dev/v1alpha1
+kind: OpenStackSecurityGroupRule
+metadata:
+  labels:
+    app.kubernetes.io/name: openstacksecuritygrouprule
+    app.kubernetes.io/instance: openstacksecuritygrouprule-sample
+    app.kubernetes.io/part-of: gopherkube
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: gopherkube
+  name: workstation-mosh-ipv4
+spec:
+  cloud: osp1
+  securityGroup: workstation
+  direction: ingress
+  description: mosh
+  portRangeMin: 60000
+  portRangeMax: 61000
+  protocol: UDP
+  etherType: IPv4
+---
+apiVersion: openstack.gopherkube.dev/v1alpha1
+kind: OpenStackSecurityGroupRule
+metadata:
+  labels:
+    app.kubernetes.io/name: openstacksecuritygrouprule
+    app.kubernetes.io/instance: openstacksecuritygrouprule-sample
+    app.kubernetes.io/part-of: gopherkube
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: gopherkube
+  name: workstation-ssh-ipv6
+spec:
+  cloud: osp1
+  securityGroup: workstation
+  direction: ingress
+  description: ssh
+  portRangeMin: 22
+  portRangeMax: 22
+  protocol: TCP
+  etherType: IPv6
+---
+apiVersion: openstack.gopherkube.dev/v1alpha1
+kind: OpenStackSecurityGroupRule
+metadata:
+  labels:
+    app.kubernetes.io/name: openstacksecuritygrouprule
+    app.kubernetes.io/instance: openstacksecuritygrouprule-sample
+    app.kubernetes.io/part-of: gopherkube
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: gopherkube
+  name: workstation-mosh-ipv6
+spec:
+  cloud: osp1
+  securityGroup: workstation
+  direction: ingress
+  description: mosh
+  portRangeMin: 60000
+  portRangeMax: 61000
+  protocol: UDP
+  etherType: IPv6

--- a/config/samples/openstack_v1alpha1_openstackserver.yaml
+++ b/config/samples/openstack_v1alpha1_openstackserver.yaml
@@ -7,6 +7,13 @@ metadata:
     app.kubernetes.io/part-of: gopherkube
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: gopherkube
-  name: openstackserver-sample
+  name: workstation
 spec:
-  # TODO(user): Add fields here
+  cloud: osp1
+  name: workstation
+  image: ubuntu
+  flavor: small
+  networks:
+  - network-1
+  securityGroups:
+  - workstation

--- a/config/samples/openstack_v1alpha1_openstacksubnet.yaml
+++ b/config/samples/openstack_v1alpha1_openstacksubnet.yaml
@@ -7,6 +7,13 @@ metadata:
     app.kubernetes.io/part-of: gopherkube
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: gopherkube
-  name: openstacksubnet-sample
+  name: network-1-subnet-1
 spec:
-  # TODO(user): Add fields here
+  cloud: osp1
+  name: subnet-1
+  network: network-1
+  allocationPools:
+  - start: 192.168.1.5
+    end: 192.168.1.60
+  cidr: 192.168.1.0/24
+  ipVersion: IPv4


### PR DESCRIPTION
This creates a set of resources on the target OpenStack cloud.

Note that the floating IP is created but not used; the server is therefore not reachable from the outside yet.

**Howto:**
1. `make`
2. `make install`
3. `make run`
4. in a separate terminal: `cp ~/.config/openstack/clouds.yaml ./config/samples/`
5. replace the IDs of the existing external network, flavor, image in the CRDs
6. `kubectl apply -k ./config/samples/`

**To remove the resources from the cloud:**
1. comment out the cloud configuration in `kustomize`:
```yaml
## Append samples of your project ##
generatorOptions:
  disableNameSuffixHash: true
# secretGenerator:
# - name: openstack-clouds
#   files:
#   - clouds.yaml
resources:
# - openstack_v1alpha1_openstackcloud.yaml
- openstack_v1alpha1_openstackflavor.yaml
- openstack_v1alpha1_openstackfloatingip.yaml
- openstack_v1alpha1_openstackimage.yaml
- openstack_v1alpha1_openstacknetwork.yaml
- openstack_v1alpha1_openstacksecuritygrouprule.yaml
- openstack_v1alpha1_openstacksecuritygroup.yaml
- openstack_v1alpha1_openstackserver.yaml
- openstack_v1alpha1_openstacksubnet.yaml
#+kubebuilder:scaffold:manifestskustomizesamples
```
2. `kubectl delete -k ./config/samples`
3. restore the full kustomize file
4. `kubectl delete -k ./config/samples`

Fixes: #31 